### PR TITLE
remove bitcoin logo from wallet header

### DIFF
--- a/www/views/tab-home.html
+++ b/www/views/tab-home.html
@@ -93,7 +93,6 @@
 
     <div class="list card" ng-if="walletsBtc[0]">
       <div class="item item-icon-right item-heading">
-        <img class="wallet-coin-logo" src="img/icon-bitcoin.svg" width="18">
         <span translate>Viacoin Wallets</span>
         <a ui-sref="tabs.add"><i class="icon ion-ios-plus-empty list-add-button"></i></a>
       </div>


### PR DESCRIPTION
I initially replaced the bitcoin logo with a viacoin one, but then I realized this logo was required because the apps has to differentiate between bitcoin and bcash wallets. Thus I removed it entirely.